### PR TITLE
Feature/multiple cast inputs

### DIFF
--- a/lolcatt/__init__.py
+++ b/lolcatt/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Lukas Lüftinger"""
 __email__ = 'lukas.lueftinger@outlook.com'
-__version__ = '0.2.3'
+__version__ = '0.3.0'

--- a/lolcatt/cli.py
+++ b/lolcatt/cli.py
@@ -17,7 +17,7 @@ from lolcatt.utils.utils import write_initial_config
 @click.version_option(__version__, '-v', '--version', prog_name='lolcatt')
 @click.argument(
     'url_or_path',
-    nargs=1,
+    nargs=-1,
     default=None,
     required=False,
 )
@@ -57,7 +57,8 @@ def main(url_or_path, device, scan, config):
 
     lolcatt = LolCatt(device_name=device, config=config)
     if url_or_path is not None:
-        lolcatt.caster.enqueue(url_or_path)
+        for up in url_or_path:
+            lolcatt.caster.enqueue(up)
         lolcatt.caster.cast_next()
     lolcatt.run()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
 '''
 
 [tool.bumpver]
-current_version = "0.2.3"
+current_version = "0.3.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 toml
 click>=8
-yt-dlp>=2023.7.6
+yt-dlp>=2024.04.09
 textual>=0.30.0
 catt

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/LokiLuciferase/lolcatt',
-    version='0.2.3',
+    version='0.3.0',
     zip_safe=False,
 )


### PR DESCRIPTION
This PR introduces the ability to pass multiple files or URLs at CLI startup like so:


```bash
lolcatt -d <device> <URL1> "<URL with whitespace>" ./filename.mp3 ...
```